### PR TITLE
Fix typo in the RepositoryUri datamember name

### DIFF
--- a/Zopa.ServiceDiagnostics/ProjectInformationAttribute.cs
+++ b/Zopa.ServiceDiagnostics/ProjectInformationAttribute.cs
@@ -13,7 +13,7 @@ namespace Zopa.ServiceDiagnostics
             Email = email;
         }
 
-        [DataMember(Name = "repositoryUr")]
+        [DataMember(Name = "repositoryUrl")]
         public string RepositoryUri { get; private set; }
 
         [DataMember(Name = "email")]


### PR DESCRIPTION
I noticed this is rendering the wrong name.

:mag: /cc @spadger 