### PR TITLE
Add cancellationtoken to async methods

### DIFF
--- a/Zopa.ServiceDiagnostics.Tests/Health/WhenADescriptiveHealthCheckThrowsAnException.cs
+++ b/Zopa.ServiceDiagnostics.Tests/Health/WhenADescriptiveHealthCheckThrowsAnException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;
@@ -25,13 +26,13 @@ namespace Zopa.ServiceDiagnostics.Tests.Health
             {
                 _healthCheck = new Mock<IAmADescriptiveHealthCheck>();
                 _healthCheck.Setup(x => x.Name).Returns(Name);
-                _healthCheck.Setup(x => x.ExecuteAsync(It.IsAny<Guid>(), It.IsAny<Stopwatch>())).Throws(_exception);
+                _healthCheck.Setup(x => x.ExecuteAsync(It.IsAny<Guid>(), It.IsAny<Stopwatch>(), CancellationToken.None)).Throws(_exception);
                 _runner = new HealthCheckRunner(new IAmAHealthCheck[0], new[] { _healthCheck.Object });
             }
 
             protected override async Task WhenAsync()
             {
-                Result = await _runner.DoAsync();
+                Result = await _runner.DoAsync(CancellationToken.None);
             }
         }
 

--- a/Zopa.ServiceDiagnostics.Tests/Health/WhenTheSystemIsHealthy.cs
+++ b/Zopa.ServiceDiagnostics.Tests/Health/WhenTheSystemIsHealthy.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;
@@ -29,14 +30,20 @@ namespace Zopa.ServiceDiagnostics.Tests.Health
                 _simpleHealthCheck.Setup(x => x.Name).Returns(Scenario.SimpleCheckName);
 
                 _descriptiveHealthCheck = new Mock<IAmADescriptiveHealthCheck>();
-                _descriptiveHealthCheck.Setup(x => x.ExecuteAsync(It.IsAny<Guid>(), It.IsAny<Stopwatch>())).ReturnsAsync(HealthCheckResult.Pass(Scenario.DescriptiveCheckName, TimeSpan.FromSeconds(123), DescriptiveCheckAdditionalMessage));
+                _descriptiveHealthCheck
+                    .Setup(x => x.ExecuteAsync(It.IsAny<Guid>(), It.IsAny<Stopwatch>(), CancellationToken.None))
+                    .ReturnsAsync(
+                        HealthCheckResult.Pass(
+                            Scenario.DescriptiveCheckName,
+                            TimeSpan.FromSeconds(123),
+                            DescriptiveCheckAdditionalMessage));
 
                 _runner = new HealthCheckRunner(new[] { _simpleHealthCheck.Object }, new[] { _descriptiveHealthCheck.Object });
             }
 
             protected override async Task WhenAsync()
             {
-                Result = await _runner.DoAsync();
+                Result = await _runner.DoAsync(CancellationToken.None);
             }
         }
 

--- a/Zopa.ServiceDiagnostics.Tests/Health/WhenTheSystemIsUnhealthy.cs
+++ b/Zopa.ServiceDiagnostics.Tests/Health/WhenTheSystemIsUnhealthy.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;
@@ -24,13 +25,13 @@ namespace Zopa.ServiceDiagnostics.Tests.Health
             {
                 _healthCheck = new Mock<IAmAHealthCheck>();
                 _healthCheck.Setup(x => x.Name).Returns(Name);
-                _healthCheck.Setup(x => x.ExecuteAsync(It.IsAny<Guid>())).Throws(_exception);
+                _healthCheck.Setup(x => x.ExecuteAsync(It.IsAny<Guid>(), CancellationToken.None)).Throws(_exception);
                 _runner = new HealthCheckRunner(new[] { _healthCheck.Object }, Enumerable.Empty<IAmADescriptiveHealthCheck>());
             }
 
             protected override async Task WhenAsync()
             {
-                Result = await _runner.DoAsync();
+                Result = await _runner.DoAsync(CancellationToken.None);
             }
         }
 

--- a/Zopa.ServiceDiagnostics/Health/Checks/HttpHealthcheck.cs
+++ b/Zopa.ServiceDiagnostics/Health/Checks/HttpHealthcheck.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Zopa.ServiceDiagnostics.Health.Checks
@@ -15,12 +16,12 @@ namespace Zopa.ServiceDiagnostics.Health.Checks
 
         public virtual string Name => $"Http healthcheck against {_uri}";
 
-        public async Task ExecuteAsync(Guid correlationId)
+        public async Task ExecuteAsync(Guid correlationId, CancellationToken cancellationToken)
         {
             var request = new HttpRequestMessage(HttpMethod.Get, _uri);
             request.Headers.Add("X-Correlation-Id", correlationId.ToString());
 
-            var response = await new HttpClient().SendAsync(request);
+            var response = await new HttpClient().SendAsync(request, cancellationToken);
 
             if (!response.IsSuccessStatusCode)
             {

--- a/Zopa.ServiceDiagnostics/Health/Checks/SqlHealthCheck.cs
+++ b/Zopa.ServiceDiagnostics/Health/Checks/SqlHealthCheck.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Data.SqlClient;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Zopa.ServiceDiagnostics.Health.Checks
@@ -17,15 +18,15 @@ namespace Zopa.ServiceDiagnostics.Health.Checks
 
         public string Name => $"Sql connection check for {_connectionName}";
 
-        public async Task ExecuteAsync(Guid correlationId)
+        public async Task ExecuteAsync(Guid correlationId, CancellationToken cancellationToken)
         {
             using (var conn = new SqlConnection(_connectionString))
             {
-                await conn.OpenAsync();
+                await conn.OpenAsync(cancellationToken);
 
                 var command = new SqlCommand("select 1", conn);
 
-                await command.ExecuteScalarAsync();
+                await command.ExecuteScalarAsync(cancellationToken);
             }
         }
     }

--- a/Zopa.ServiceDiagnostics/Health/IAmADescriptiveHealthCheck.cs
+++ b/Zopa.ServiceDiagnostics/Health/IAmADescriptiveHealthCheck.cs
@@ -1,12 +1,13 @@
 using System;
 using System.Diagnostics;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Zopa.ServiceDiagnostics.Health
 {
     public interface IAmADescriptiveHealthCheck
     {
-        Task<HealthCheckResult> ExecuteAsync(Guid correlationId, Stopwatch sw);
+        Task<HealthCheckResult> ExecuteAsync(Guid correlationId, Stopwatch sw, CancellationToken cancellationToken);
 
         string Name { get; }
     }

--- a/Zopa.ServiceDiagnostics/Health/IAmAHealthCheck.cs
+++ b/Zopa.ServiceDiagnostics/Health/IAmAHealthCheck.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Zopa.ServiceDiagnostics.Health
@@ -11,7 +12,8 @@ namespace Zopa.ServiceDiagnostics.Health
         /// Runs the actual health check
         /// </summary>
         /// <param name="correlationId">Each unique run of all checks will have an associated correlation id to help tie your logs together (assuming you log such things)</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/>.</param>
         /// <returns>Anyhting if the check was successful. A health check's run is marked as unsuccessful if this method throws an exception</returns>
-        Task ExecuteAsync(Guid correlationId);
+        Task ExecuteAsync(Guid correlationId, CancellationToken cancellationToken);
     }
 }

--- a/Zopa.ServiceDiagnostics/Health/IHealthCheckRunner.cs
+++ b/Zopa.ServiceDiagnostics/Health/IHealthCheckRunner.cs
@@ -1,9 +1,10 @@
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Zopa.ServiceDiagnostics.Health
 {
     public interface IHealthCheckRunner
     {
-        Task<HealthCheckResults> DoAsync();
+        Task<HealthCheckResults> DoAsync(CancellationToken cancellationToken);
     }
 }


### PR DESCRIPTION
Health checks can take time to execute, which is why they are async, however if a shutdown signal is received the health check should not delay the shutdown of the application.

Note: this is a breaking change to the API due to the interface changes

https://youtrack.zopian.ad.zopa.com/issue/NO-Tick

:mag: /cc @spadger 